### PR TITLE
Remove solid_cable dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,7 @@ gem 'bcrypt', '~> 3.1.22'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[windows jruby]
 
-# Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
-gem 'solid_cable'
+# Use the database-backed adapters for Rails.cache and Active Job
 gem 'solid_cache'
 gem 'solid_queue'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,11 +394,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
     smart_properties (1.17.0)
-    solid_cable (4.0.0)
-      actioncable (>= 7.2)
-      activejob (>= 7.2)
-      activerecord (>= 7.2)
-      railties (>= 7.2)
     solid_cache (1.0.10)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -501,7 +496,6 @@ DEPENDENCIES
   rubocop-rails-omakase
   sass-rails (>= 6)
   selenium-webdriver
-  solid_cable
   solid_cache
   solid_queue
   stimulus-rails


### PR DESCRIPTION
Action Cable wird nicht genutzt, daher kann auch `solid_cable` als Abhängikeit raus